### PR TITLE
bugfix: #12 - wrap divisions calculations in the calc() function

### DIFF
--- a/public/sass-flexbox/scss/_grid.scss
+++ b/public/sass-flexbox/scss/_grid.scss
@@ -66,12 +66,12 @@
   @for $i from 1 through $grid-columns {
     .col-#{$thisPrefix}-#{$i} {
       box-sizing: border-box;
-      flex-basis: 100% / $grid-columns * $i;
-      max-width: 100% / $grid-columns * $i;
+      flex-basis: calc(100% / $grid-columns * $i);
+      max-width: calc(100% / $grid-columns * $i);
       padding: $gutter;
     }
     .col-#{$thisPrefix}-offset-#{$i} {
-      margin-left: 100% / $grid-columns * $i;
+      margin-left: calc(100% / $grid-columns * $i);
     }
   }
   .row.start-#{$thisPrefix} {

--- a/public/sass-flexbox/scss/mixins/_grid-mixins.scss
+++ b/public/sass-flexbox/scss/mixins/_grid-mixins.scss
@@ -38,8 +38,8 @@
       @warn "Column number must be greater than 0 and less than or equal to total number of columns in the grid (#{$grid-columns})";
     } @else {
       box-sizing: border-box;
-      flex-basis: 100% / $grid-columns * $col-number;
-      max-width: 100% / $grid-columns * $col-number;
+      flex-basis: calc(100% / $grid-columns * $col-number);
+      max-width: calc(100% / $grid-columns * $col-number);
       padding: $gutter;
     }
   // If no col number is passed then arg is set to "auto" by default
@@ -92,7 +92,7 @@
   } @else if $offset-number > $grid-columns {
     @warn "Column offset number must be greater than 0 and less than or equal to total number of columns in the grid (#{$grid-columns})";
   } @else {
-    margin-left: 100% / $grid-columns * $offset-number;
+    margin-left: calc(100% / $grid-columns * $offset-number);
   }
 } // Condition to run inside of the col-offset mixin * not for developer use *
 


### PR DESCRIPTION
In dart-sass > 2.0.0 calculations with a division must be wrapped in the calc() function. (To account for features since added to CSS that use `/` as a separator for shorthand notations, e.g. grid).

I've only updated the SCSS files as I had trouble getting dependencies installed on my M1 Macbook - this is likely either the old dependencies using pre-compiled node extensions. I thought I'd get this PR up regardless so that anyone could take this commit as an atomic patch to apply to the SCSS files if necessary.